### PR TITLE
Implement gradual health regeneration

### DIFF
--- a/js/entities.js
+++ b/js/entities.js
@@ -78,7 +78,7 @@ export class Entity {
         let chance = this.maxHp <= 5 ? 0.1 : this.maxHp > 8 ? 0.3 : 0.2;
         const isMaxHit = Math.random() < chance;
         const dmg = isMaxHit ? 15 : Math.floor(Math.random() * 11) + 4;
-        player.hp = Math.max(0, player.hp - dmg);
+        player.takeDamage(dmg);
         spawnBloodEffect(player.x + player.w/2, player.y + player.h/2, dmg);
       }
     }

--- a/js/player.js
+++ b/js/player.js
@@ -6,8 +6,11 @@ export class Player {
     this.w = 32; this.h = 32;
     this.speed = 2;
     this.hp = this.maxHp = 100;
+    this.lastDamage = performance.now();
+    this.lastRegen  = performance.now();
   }
   update(keys, mapObjects) {
+    const now = performance.now();
     let nx = this.x, ny = this.y;
     if (keys.ArrowLeft || keys.KeyA)  nx -= this.speed;
     if (keys.ArrowRight|| keys.KeyD)  nx += this.speed;
@@ -19,9 +22,25 @@ export class Player {
     if (!collidesWithMap(this.x, ny, this.w, this.h, mapObjects)) {
       this.y = ny;
     }
+
+    if (
+      this.hp < this.maxHp &&
+      now - this.lastDamage >= 5000 &&
+      now - this.lastRegen >= 1000
+    ) {
+      this.hp = Math.min(this.maxHp, this.hp + 1);
+      this.lastRegen = now;
+    }
   }
   draw(ctx) {
     ctx.fillStyle = 'royalblue';
     ctx.fillRect(this.x, this.y, this.w, this.h);
+  }
+
+  takeDamage(dmg) {
+    this.hp = Math.max(0, this.hp - dmg);
+    const now = performance.now();
+    this.lastDamage = now;
+    this.lastRegen  = now;
   }
 }

--- a/js/skeleton.js
+++ b/js/skeleton.js
@@ -36,7 +36,7 @@ export class Skeleton {
     let chance = this.maxHp <= 5 ? 0.1 : this.maxHp > 8 ? 0.3 : 0.2;
     const isMaxHit = Math.random() < chance;
     const dmg = isMaxHit ? 15 : 4 + Math.floor(Math.random()*11);
-    player.hp = Math.max(0, player.hp - dmg);
+    player.takeDamage(dmg);
     spawnBloodEffect(player.x+player.w/2, player.y+player.h/2, dmg);
     return player.hp <= 0;
   }


### PR DESCRIPTION
## Summary
- add damage tracking and regen logic to the Player
- call `takeDamage` from Skeleton (and unused Entity) attacks

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6845ea085124832da2f4032950ad3c31