### PR TITLE
Add monster health bars

### DIFF
--- a/js/skeleton.js
+++ b/js/skeleton.js
@@ -28,6 +28,13 @@ export class Skeleton {
     const shade = 255 - (this.maxHp/10)*200;
     ctx.fillStyle = `rgb(${shade},${shade},${shade})`;
     ctx.fillRect(this.x, this.y, this.w, this.h);
+
+    const barHeight = 3;
+    const barWidth = this.w;
+    const barX = this.x;
+    const barY = this.y - barHeight - 2;
+    ctx.fillStyle = 'red';
+    ctx.fillRect(barX, barY, barWidth * (this.hp / this.maxHp), barHeight);
   }
   tryAttack(now, player, spawnBloodEffect) {
     if (now - this.lastAttack < this.attackCD) return false;


### PR DESCRIPTION
## Summary
- draw small red health bars above skeleton enemies

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845ea4278a0832d9919633773ecc162