### PR TITLE
Allow screen wrapping movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ enemies.
 The battlefield now has several layouts that are picked at random. Each
 layout contains fewer obstacles so the player always spawns in a clear
 area and enemies have more room to move.
+
+## Boundless movement
+
+Leaving the screen now wraps the player to the opposite side, removing the
+blocking fence around the arena.

--- a/js/main.js
+++ b/js/main.js
@@ -59,7 +59,7 @@ function loop() {
 
   // оновлення
   if (!isEnd) {
-    player.update(keys, gameObjects);
+    player.update(keys, gameObjects, WIDTH, HEIGHT);
     enemies.forEach(e => e.update(player, gameObjects));
     bullets.forEach(b => b.update(gameObjects));
   }

--- a/js/map.js
+++ b/js/map.js
@@ -56,11 +56,7 @@ function openMap(objects) {
 export function createMap() {
   const objects = [];
 
-  // field boundaries
-  objects.push(new Environment('fence', 0,   0,   800, 32));
-  objects.push(new Environment('fence', 0,   568, 800, 32));
-  objects.push(new Environment('fence', 0,   0,   32,  600));
-  objects.push(new Environment('fence', 768, 0,   32,  600));
+  // no outer boundary fences
 
   const generators = [baseMap, forestMap, openMap];
   const gen = generators[Math.floor(Math.random()*generators.length)];

--- a/js/player.js
+++ b/js/player.js
@@ -9,7 +9,7 @@ export class Player {
     this.lastDamage = performance.now();
     this.lastRegen  = performance.now();
   }
-  update(keys, mapObjects) {
+  update(keys, mapObjects, width, height) {
     const now = performance.now();
     let nx = this.x, ny = this.y;
     if (keys.ArrowLeft || keys.KeyA)  nx -= this.speed;
@@ -22,6 +22,12 @@ export class Player {
     if (!collidesWithMap(this.x, ny, this.w, this.h, mapObjects)) {
       this.y = ny;
     }
+
+    // wrap around screen when leaving bounds
+    if (this.x + this.w < 0) this.x = width;
+    else if (this.x > width) this.x = -this.w;
+    if (this.y + this.h < 0) this.y = height;
+    else if (this.y > height) this.y = -this.h;
 
     if (
       this.hp < this.maxHp &&


### PR DESCRIPTION
## Summary
- remove outer fence generation for boundless map
- wrap player coordinates so moving past an edge reappears on the opposite side
- document new behaviour in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684692e449c0832db9e51379ca6a6da7