### PR TITLE
Fix game freeze after restart

### DIFF
--- a/js/phaserGame.js
+++ b/js/phaserGame.js
@@ -27,6 +27,17 @@ class MainScene extends Phaser.Scene {
   }
 
   create() {
+    // reset state when restarting
+    this.gameOver = false;
+    this.shooting = false;
+    this.lastShot = 0;
+    this.kills = 0;
+    this.totalEnemies = 0;
+    this.bloodParticles = [];
+    if (this.physics.world.isPaused) {
+      this.physics.resume();
+    }
+
     const width = this.scale.width;
     const height = this.scale.height;
 


### PR DESCRIPTION
## Summary
- reset scene state when restarting and resume physics

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846bd8ca800832d97441bc931c905ab