### PR TITLE
Fix bullet gravity call

### DIFF
--- a/js/phaserGame.js
+++ b/js/phaserGame.js
@@ -208,7 +208,8 @@ class MainScene extends Phaser.Scene {
       const bullet = this.physics.add.image(this.player.x, this.player.y, 'bulletPixel');
       bullet.setDisplaySize(6, 6);
       bullet.setTint(0xffff00);
-      bullet.setAllowGravity(false);
+      // Disable gravity on the bullet's physics body so it travels straight
+      bullet.body.setAllowGravity(false);
       bullet.setCollideWorldBounds(false);
       bullet.setVelocity((dx / len) * 300, (dy / len) * 300);
       this.bullets.add(bullet);


### PR DESCRIPTION
## Summary
- avoid calling nonexistent `setAllowGravity` on bullets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846c1026c74832d88910a6cbebd83be