### PR TITLE
Fix bullet movement issue

### DIFF
--- a/js/phaserGame.js
+++ b/js/phaserGame.js
@@ -208,9 +208,10 @@ class MainScene extends Phaser.Scene {
       const bullet = this.physics.add.image(this.player.x, this.player.y, 'bulletPixel');
       bullet.setDisplaySize(6, 6);
       bullet.setTint(0xffff00);
-      bullet.setAllowGravity(false);
-      bullet.setCollideWorldBounds(false);
-      bullet.setVelocity((dx / len) * 300, (dy / len) * 300);
+      // Disable gravity on the bullet's physics body so it travels straight
+      bullet.body.setAllowGravity(false);
+      bullet.body.setCollideWorldBounds(false);
+      bullet.body.setVelocity((dx / len) * 300, (dy / len) * 300);
       this.bullets.add(bullet);
 
       this.lastShot = time;


### PR DESCRIPTION
## Summary
- ensure the bullet uses Arcade Physics body methods when fired

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846c1026c74832d88910a6cbebd83be